### PR TITLE
Adapt to https://github.com/math-comp/math-comp/pull/1246

### DIFF
--- a/bigenough.v
+++ b/bigenough.v
@@ -101,7 +101,6 @@ Ltac olddone :=
    trivial; hnf; intros; solve
    [ do ![solve [trivial | apply: sym_equal; trivial]
          | discriminate | contradiction | split]
-   | case not_locked_false_eq_true; assumption
    | match goal with H : ~ _ |- _ => solve [case H; trivial] end].
 
 Ltac big_enough :=


### PR DESCRIPTION
We discovered this line is now useless during CUDW. Probably not any noticeable speed-up (haven't measured) but still good as a cleanup.

Successfully tested on https://github.com/math-comp/math-comp/pull/1246